### PR TITLE
Article updates: 20250724T2330

### DIFF
--- a/articles/20250724T2330-npr-questions-about-epstein-files-follow-lawmakers-home.md
+++ b/articles/20250724T2330-npr-questions-about-epstein-files-follow-lawmakers-home.md
@@ -1,0 +1,9 @@
+---
+url: https://www.npr.org/2025/07/24/nx-s1-5478924/trump-epstein-congress
+title: Questions about Epstein files follow lawmakers home
+publisher: npr
+usage: top
+initial_rank: 1
+---
+## Article summary
+As lawmakers head home for a recess, many are facing calls for transparency regarding the Department of Justice's investigation into Jeffrey Epstein. Republican Rep. Ryan Mackenzie of Pennsylvania, during a town hall, expressed support for releasing the DOJ files on Epstein if the White House does not act. President Trump has recently faced criticism from his supporters who distrust the DOJ's conclusions about Epstein's "client list" and his death in 2019. Democratic groups are targeting Republican lawmakers, seeing the Epstein saga as a political liability and a divisive issue within the GOP. Republican strategist Rina Shah noted that the push for transparency on Epstein could reshape the party, with a potential House vote in September being a defining moment for the GOP.

--- a/articles/20250724T2330-npr-trump-administration-approves-sale-of-cbs-parent-company-paramount.md
+++ b/articles/20250724T2330-npr-trump-administration-approves-sale-of-cbs-parent-company-paramount.md
@@ -1,0 +1,9 @@
+---
+url: https://www.npr.org/2025/07/24/nx-s1-5477530/paramount-cbs-skydance-sale-fcc-approves
+title: Trump administration approves sale of CBS parent company Paramount
+publisher: npr
+usage: candidate
+initial_rank: 2
+---
+## Article summary
+The Trump administration, through the Federal Communications Commission (FCC), approved the $8 billion sale of Paramount Global to Skydance Media. This approval came after Paramount and the Ellison family took steps to address concerns raised by the Trump administration regarding CBS's news coverage. Key concessions included canceling "The Late Show with Stephen Colbert," eliminating U.S.-based Diversity, Equity, and Inclusion (DEI) programs, and creating an ombudsman to address complaints of ideological bias. Additionally, Paramount settled a lawsuit filed by Trump for $16 million. FCC Chair Brendan Carr praised these changes, stating they exposed partisan biases in media and were a result of Trump's influence.

--- a/articles/20250724T2330-npr-trump-visits-federal-reserve-and-tussles-with-jerome-powell-in-extraordinary-moment.md
+++ b/articles/20250724T2330-npr-trump-visits-federal-reserve-and-tussles-with-jerome-powell-in-extraordinary-moment.md
@@ -1,0 +1,10 @@
+---
+url: https://www.npr.org/2025/07/24/nx-s1-5478922/trump-federal-reserve-renovation-jerome-powell
+title: Trump visits Federal Reserve and tussles with Jerome Powell in extraordinary
+  moment
+publisher: npr
+usage: candidate
+initial_rank: 3
+---
+## Article summary
+President Trump visited the Federal Reserve to inspect renovations and publicly disagreed with Fed Chair Jerome Powell about the project's cost, with Trump claiming it had reached $3.1 billion and Powell disputing the figure. The renovation's cost has risen from $1.9 billion to $2.5 billion, becoming a point of contention as Trump pressures the Fed to lower interest rates. Trump's visit was unusual, as presidents typically avoid interfering with the Fed's independence. Trump has repeatedly criticized Powell, even threatening to fire him, but Powell has stated he intends to complete his term. The Fed's recent interest rate decisions and inflation concerns make it unlikely they will cut rates soon, despite Trump's pressure.

--- a/articles/20250724T2330-nytimes-hulk-hogan-superstar-of-pro-wrestling-dies-at-71the-charismatic-entertainer-helped-transform-professional-wrestling-into-a-multibillion-dollar-industry.md
+++ b/articles/20250724T2330-nytimes-hulk-hogan-superstar-of-pro-wrestling-dies-at-71the-charismatic-entertainer-helped-transform-professional-wrestling-into-a-multibillion-dollar-industry.md
@@ -1,0 +1,10 @@
+---
+url: https://www.nytimes.com/2025/07/24/sports/hulk-hogan-dead.html
+title: Hulk Hogan, Superstar of Pro Wrestling, Dies at 71The charismatic entertainer
+  helped transform professional wrestling into a multibillion-dollar industry.
+publisher: nytimes
+usage: top
+initial_rank: 1
+---
+## Article summary
+Hulk Hogan, the legendary wrestling superstar known for his flamboyant persona and massive biceps, has died at the age of 71. Hogan, born Terry Gene Bollea, rose to fame in the wrestling world, becoming a central figure in the industry's transformation into a multibillion-dollar enterprise. His iconic character, complete with blond hair, a horseshoe mustache, and colorful bandannas, captivated fans worldwide, leading to the phenomenon known as Hulkamania. Hogan's career spanned decades, including notable appearances in movies like "Rocky III" and a controversial lawsuit against Gawker, which he won. Despite controversies and setbacks, Hogan remained a beloved figure in wrestling and pop culture, leaving behind a lasting legacy.

--- a/articles/20250724T2330-nytimes-the-wrestling-ropes-couldnt-constrain-hulk-hogan.md
+++ b/articles/20250724T2330-nytimes-the-wrestling-ropes-couldnt-constrain-hulk-hogan.md
@@ -1,0 +1,9 @@
+---
+url: https://www.nytimes.com/2025/07/24/arts/hulk-hogan-wrestling-movies-rocky-.html
+title: "The Wrestling Ropes Couldn\u2019t Constrain Hulk Hogan"
+publisher: nytimes
+usage: candidate
+initial_rank: 3
+---
+## Article summary
+Hulk Hogan, the iconic wrestler with a patriotic persona, died at 71. He was instrumental in wrestling's rise in the 1980s, becoming a crossover star in movies, TV, and commercials. Hogan's career highlights include his role in "Rocky III," his legendary match against Andre the Giant at WrestleMania III, and his controversial heel turn in World Championship Wrestling. Later, he became a vocal Republican supporter, speaking at the 2024 Republican National Convention and endorsing Donald Trump. Hogan also briefly flirted with politics, teasing a presidential run in 1998 and expressing interest in being Trump's vice-presidential running mate.

--- a/articles/20250724T2330-nytimes-watch.md
+++ b/articles/20250724T2330-nytimes-watch.md
@@ -1,0 +1,9 @@
+---
+url: https://www.nytimes.com/video/us/politics/100000009581267/hulk-hogan-rips-shirt-off-during-rnc-speech.html
+title: 'Watch: Hulk Hogan Rips Shirt Off During 2024 R.N.C. Speech'
+publisher: nytimes
+usage: candidate
+initial_rank: 2
+---
+## Article summary
+Hulk Hogan made a notable appearance at the Republican National Convention, where he tore off his shirt to reveal a Trump/Vance tank top. His speech was a show of support for Donald Trump and J.D. Vance. Hogan referenced a recent event where he believed Trump was unfairly attacked and declared, "Enough was enough." He encouraged the crowd to embrace "Trumpamania," urging it to "run wild" and "rule again." The stunt was a dramatic display of enthusiasm for the Trump-Vance ticket.


### PR DESCRIPTION
- article from npr usage top initial rank 1 with title 'Questions about Epstein files follow lawmakers home ![](https://media.dev.thiswas.news/screenshot/20250724T2330/20250724T2330-npr-questions-about-epstein-files-follow-lawmakers-home.topcrop.png)
- article from npr usage candidate initial rank 2 with title 'Trump administration approves sale of CBS parent company Paramount ![](https://media.dev.thiswas.news/screenshot/20250724T2330/20250724T2330-npr-trump-administration-approves-sale-of-cbs-parent-company-paramount.topcrop.png)
- article from npr usage candidate initial rank 3 with title 'Trump visits Federal Reserve and tussles with Jerome Powell in extraordinary moment ![](https://media.dev.thiswas.news/screenshot/20250724T2330/20250724T2330-npr-trump-visits-federal-reserve-and-tussles-with-jerome-powell-in-extraordinary-moment.topcrop.png)
- article from nytimes usage top initial rank 1 with title 'Hulk Hogan, Superstar of Pro Wrestling, Dies at 71The charismatic entertainer helped transform professional wrestling into a multibillion-dollar industry. ![](https://media.dev.thiswas.news/screenshot/20250724T2330/20250724T2330-nytimes-hulk-hogan-superstar-of-pro-wrestling-dies-at-71the-charismatic-entertainer-helped-transform-professional-wrestling-into-a-multibillion-dollar-industry.topcrop.png)
- article from nytimes usage candidate initial rank 2 with title 'Watch: Hulk Hogan Rips Shirt Off During 2024 R.N.C. Speech ![](https://media.dev.thiswas.news/screenshot/20250724T2330/20250724T2330-nytimes-watch.topcrop.png)
- article from nytimes usage candidate initial rank 3 with title 'The Wrestling Ropes Couldn’t Constrain Hulk Hogan ![](https://media.dev.thiswas.news/screenshot/20250724T2330/20250724T2330-nytimes-the-wrestling-ropes-couldnt-constrain-hulk-hogan.topcrop.png)